### PR TITLE
Add JUnit tests for Most Frequent Words Analyzer Kata

### DIFF
--- a/src/_training/Kata4kyu/mostFrequentWords/WordFrequencyAnalyzer.java
+++ b/src/_training/Kata4kyu/mostFrequentWords/WordFrequencyAnalyzer.java
@@ -1,4 +1,30 @@
 package _training.Kata4kyu.mostFrequentWords;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
 public class WordFrequencyAnalyzer {
+
+    public static List<String> mostFrequentWords(String text, List<String> stopwords) {
+        Set<String> stop = new HashSet<>();
+        for (String s : stopwords) {
+            stop.add(s.toLowerCase());
+        }
+
+        Map<String, Integer> freq = new HashMap<>();
+
+        String[] words = text.toLowerCase().replaceAll("[^a-z\\s]", "").split("\\s+");
+
+        for (String word : words) {
+            if (!word.isEmpty() && !stop.contains(word)) {
+                freq.put(word, freq.getOrDefault(word, 0) + 1);
+            }
+        }
+
+        return freq.entrySet().stream()
+                .sorted(Comparator.<Map.Entry<String, Integer>>comparingInt(Map.Entry::getValue).reversed()
+                        .thenComparing(Map.Entry::getKey))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
 }

--- a/test/_training/Kata4kyu/mostFrequentWords/WordFrequencyAnalyzerTest.java
+++ b/test/_training/Kata4kyu/mostFrequentWords/WordFrequencyAnalyzerTest.java
@@ -1,0 +1,52 @@
+package _training.Kata4kyu.mostFrequentWords;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WordFrequencyAnalyzerTest {
+
+    @Test
+    public void testSimpleFrequency() {
+        String text = "Hello hello world. The world is beautiful. Hello again.";
+        List<String> stopwords = List.of("the", "is");
+
+        List<String> result = WordFrequencyAnalyzer.mostFrequentWords(text, stopwords);
+
+        assertEquals("hello", result.get(0));
+        assertEquals("world", result.get(1));
+        assertTrue(result.contains("again"));
+        assertTrue(result.contains("beautiful"));
+    }
+
+    @Test
+    public void testEmptyText() {
+        String text = "";
+        List<String> stopwords = List.of("the", "is");
+
+        List<String> result = WordFrequencyAnalyzer.mostFrequentWords(text, stopwords);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testOnlyStopwords() {
+        String text = "The is the is IS the THE";
+        List<String> stopwords = List.of("the", "is");
+
+        List<String> result = WordFrequencyAnalyzer.mostFrequentWords(text, stopwords);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testTieBreakAlphabeticalOrder() {
+        String text = "cat dog dog cat apple";
+        List<String> stopwords = List.of();
+
+        List<String> result = WordFrequencyAnalyzer.mostFrequentWords(text, stopwords);
+
+        // "cat" and "dog" have same frequency (2), so alphabetical order matters
+        assertEquals(List.of("cat", "dog", "apple"), result.subList(0, 3));
+    }
+}


### PR DESCRIPTION
This pull request adds automated JUnit 5 tests for the "Most Frequent Words" kata.

✔️ What’s tested:
- Word frequency counting with punctuation removal and lowercase normalization
- Exclusion of stopwords from frequency map
- Correct sorting by frequency (descending) and alphabetically on ties
- Edge cases: empty input, input with only stopwords, tie-breaking

These tests ensure the correctness and robustness of the word frequency analyzer.